### PR TITLE
Replaced "server_message()"

### DIFF
--- a/html/assets/console.php
+++ b/html/assets/console.php
@@ -19,12 +19,16 @@ if(isset($_REQUEST['d'])&&isset($_REQUEST['s'])) {
 			$screen = $_REQUEST['s'];
 			$filename = '/var/www/factorio/'.$server_select.'/screenlog.0';  //about 500MB
 			$find=array("<", ">", "\\");
-			$repl=array("&lt;", "&gt;", "&#92;");
+			$repl=array("&lt;", "&gt;", "");
 			if($screen=="chat") {
-				$output = str_replace($find, $repl, shell_exec('grep -E -i \'CHAT|shout|\\[WEB\' '.$filename.' | tail -n 75'));
+				$output = shell_exec('grep -E -i \'CHAT|shout|\\[WEB\' '.$filename.' | tail -n 75');
+				if(preg_match('/\/silent-command\sgame.print\(.+\"..".+\"\)/i', $output)) {
+					$output = preg_replace(array('/\/silent-command\sgame.print\(\"\[WEB\]/i', '/\"..\"/', '/\"\)/'), array('[WEB] ', '', ''), $output);
+				}
+				$output = str_replace($find, $repl, $output);
 				echo str_replace(PHP_EOL, '', $output);         //add newlines
 			} elseif($screen=="console") {
-				$output = str_replace($find, $repl, shell_exec('grep -E -v \'CHAT|shout|\\[WEB|server_message\' '.$filename.' | tail -n 75'));
+				$output = str_replace($find, $repl, shell_exec('grep -E -v \'CHAT|shout|\\[WEB\' '.$filename.' | tail -n 75'));
 				echo str_replace(PHP_EOL, '', $output);         //add newlines
 			}
 		}

--- a/html/process.php
+++ b/html/process.php
@@ -96,7 +96,7 @@ if(isset($_REQUEST['start'])) {
 			}
 			if(substr($command_decode,0,1) != "/") {
 				$command = str_replace(array("\""), array('\\\"'), $command_decode);
-				$command = "/silent-command server_message(\"".$current_user."\", \"".$command."\")";
+				$command = "/silent-command game.print(\"[WEB]".$current_user.": \"..\"".$command."\")";
 			}
 			$command = str_replace(array("'", "^"), array("'\"'\"'", "\^"), $command);
 			system("sudo -u www-data /usr/bin/screen -S ".$server_select." -X at 0 stuff '".$command."\n'");


### PR DESCRIPTION
Replaced “server_message()” with “game.print()”. Much cleaner, and
doesn’t require a special scenario command to run.

Next step: removing “server_message()” from the scenario’s
