### PR TITLE
Fixed force kill

### DIFF
--- a/html/assets/base.js
+++ b/html/assets/base.js
@@ -1063,6 +1063,29 @@ function server_sss(cmd) {
 		}
 	};
 }
+function force_kill(cmd) {
+	if(user_level == "guest") {
+        alert("Guests may not force kill the server(s)");
+        return;
+    }
+	if(cmd == "forcekill") {
+        var r = confirm("WARNING: This will force kill ALL servers.");
+        if (r == true) {
+            var http = new XMLHttpRequest();
+			http.open("POST", "process.php?d=" + server_select, true);
+			http.setRequestHeader("Content-type","application/x-www-form-urlencoded");
+			var server_name = $('#server_name').val();
+			var server_password = $('#server_password').val();
+			var params = cmd + "&server_name=" + server_name + "&server_password=" + server_password;
+			http.send(params);
+			http.onload = function() {
+				if(http.responseText) {
+					alert(http.responseText);
+				}
+			};
+        }
+    }
+}
 function command() {
     if(user_level == "guest") {
         alert("Guests may not send commands :(");

--- a/html/index.php
+++ b/html/index.php
@@ -121,7 +121,7 @@
 			<form action="./update_web_control.php" method="POST" id="update_web_control" style="display: none;">
 				<input type="hidden" id="update" name="update" value="yes" />
 			</form>
-			<button onclick="server_sss('forcekill')">force kill</button>&nbsp;-&nbsp;
+			<button onclick="force_kill('forcekill')">force kill</button>&nbsp;-&nbsp;
 			<div style="float: right;">
 				<select id="server_select"></select>&nbsp;-&nbsp;
 				<a href="login.php?logout">Logout</a>

--- a/html/index.php
+++ b/html/index.php
@@ -121,7 +121,7 @@
 			<form action="./update_web_control.php" method="POST" id="update_web_control" style="display: none;">
 				<input type="hidden" id="update" name="update" value="yes" />
 			</form>
-			<button onclick="force_kill('forcekill')">force kill</button>&nbsp;-&nbsp;
+			<button onclick="force_kill('forcekill')">force kill</button>
 			<div style="float: right;">
 				<select id="server_select"></select>&nbsp;-&nbsp;
 				<a href="login.php?logout">Logout</a>


### PR DESCRIPTION
Put force kill into it’s own function.
Get rid of bogus text after force kill button.